### PR TITLE
Restrict which Bluetooth devices are allowed to connect to C1-10P

### DIFF
--- a/main/include/SettingsBluetooth.h
+++ b/main/include/SettingsBluetooth.h
@@ -2,15 +2,15 @@
 #define __SETTINGS_BLUETOOTH_H__
 
 // JoyCon(L) Pink
-// #define C110P_CONTROLLER_LEFT_MAC_ADDRESS             "5C:52:1E:FF:6E:A2"
+// #define C110P_CONTROLLER_LEFT_MAC_ADDRESS             "0A:00:0A:AA:0A:A0"
 
 // JoyCon(R) Green
-// #define C110P_CONTROLLER_RIGHT_MAC_ADDRESS            "5C:52:1E:FF:51:45"
+// #define C110P_CONTROLLER_RIGHT_MAC_ADDRESS            "0A:00:0A:AA:0A:A1"
 
 // JoyCon(L) White
-#define C110P_CONTROLLER_LEFT_MAC_ADDRESS           "98:E6:B9:62:6E:58"
+#define C110P_CONTROLLER_LEFT_MAC_ADDRESS           "0A:00:0A:AA:0A:A2"
 
 // JoyCon(R) Gray
-#define C110P_CONTROLLER_RIGHT_MAC_ADDRESS          "98:E6:B9:5A:CA:74"
+#define C110P_CONTROLLER_RIGHT_MAC_ADDRESS          "0A:00:0A:AA:0A:A3"
 
 #endif

--- a/main/include/SettingsBluetooth.h
+++ b/main/include/SettingsBluetooth.h
@@ -1,0 +1,16 @@
+#ifndef __SETTINGS_BLUETOOTH_H__
+#define __SETTINGS_BLUETOOTH_H__
+
+// JoyCon(L) Pink
+// #define C110P_CONTROLLER_LEFT_MAC_ADDRESS             "5C:52:1E:FF:6E:A2"
+
+// JoyCon(R) Green
+// #define C110P_CONTROLLER_RIGHT_MAC_ADDRESS            "5C:52:1E:FF:51:45"
+
+// JoyCon(L) White
+#define C110P_CONTROLLER_LEFT_MAC_ADDRESS           "98:E6:B9:62:6E:58"
+
+// JoyCon(R) Gray
+#define C110P_CONTROLLER_RIGHT_MAC_ADDRESS          "98:E6:B9:5A:CA:74"
+
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -15,6 +15,8 @@
 #include <arduino_platform.h>
 #include <uni.h>
 
+#include "SettingsBluetooth.h"
+
 //
 // Autostart
 //
@@ -42,6 +44,29 @@ int app_main(void) {
 
     // Init Bluepad32.
     uni_init(0 /* argc */, NULL /* argv */);
+
+    // Array of human-readable Bluetooth addresses to add to the allowlist
+    const char* controller_addresses[] = {
+        C110P_CONTROLLER_LEFT_MAC_ADDRESS,
+        C110P_CONTROLLER_RIGHT_MAC_ADDRESS
+    };
+
+    // Loop through the addresses and add them to the allowlist
+    for (size_t i = 0; i < sizeof(controller_addresses) / sizeof(controller_addresses[0]); i++) {
+        bd_addr_t controller_addr;
+        // Parse human-readable Bluetooth address.
+        sscanf_bd_addr(controller_addresses[i], controller_addr);
+
+        // Notice that this address will be added in the Non-volatile-storage (NVS).
+        // If the device reboots, the address will still be stored.
+        // Adding a duplicate value will do nothing.
+        // You can add up to four entries in the allowlist.
+        uni_bt_allowlist_add_addr(controller_addr);
+    }
+    
+    // Finally, enable the allowlist.
+    // Similar to the "add_addr", its value gets stored in the NVS.
+    uni_bt_allowlist_set_enabled(true);
 
     // Does not return.
     btstack_run_loop_execute();


### PR DESCRIPTION
This will allow us to define up to 4 Controllers to connect to the main controller:
https://bluepad32.readthedocs.io/en/latest/FAQ/#how-to-pair-just-one-controller-to-one-particular-board

This way when we are in public, nobody other than the defined controllers are allowed to connect and controll C1-10P.

Do we want to turn this on now, or save for testing later?

Should we  remove/hide the addresses from public repo, or is this okay?