### PR TITLE
Allow new JoyCons to connect to system

### DIFF
--- a/main/include/chopper/core/ControllerRoles.h
+++ b/main/include/chopper/core/ControllerRoles.h
@@ -1,9 +1,10 @@
 #pragma once
 
+// align identifier with playerLED on controller for easy identifcation of role
 enum class ControllerRoles
 {
-    Drive,
-    Dome,
-    Animation,
-    Camera,
+    Drive = 1,      // 0001
+    Dome = 3,       // 0011
+    Animation = 7,  // 0111
+    Camera = 15,    // 1111
 };

--- a/main/include/chopper/core/Controllers.h
+++ b/main/include/chopper/core/Controllers.h
@@ -48,14 +48,19 @@ public:
             DEBUG_CONTROLLER_PRINTF("Invalid MAC address: %s\n", macAddress.c_str());
             return;
         }
+        ctl->setPlayerLEDs(static_cast<int>(*optRole));
+        ctl->playDualRumble(10, 1250, 0x80, 0x40);
         if (_ctls[*optRole] != nullptr)
         {
-            DEBUG_CONTROLLER_PRINTF("Controller already exists for role: %d\n", *optRole);
+            DEBUG_CONTROLLER_PRINTF("Controller already exists for role: %d\n", optRole);
             return;
         }
         ControllerProperties properties = ctl->getProperties();
-        DEBUG_CONTROLLER_PRINTF("Controller model: %s, VID=0x%04x, PID=0x%04x, index=%d\n", ctl->getModelName(), properties.vendor_id,
-                        properties.product_id, *optRole);
+        DEBUG_CONTROLLER_PRINTF("Controller model: %s, VID=0x%04x, PID=0x%04x, role=%d\n", 
+            ctl->getModelName().c_str(), 
+            properties.vendor_id,
+            properties.product_id, 
+            optRole);
         _ctls[*optRole] = new ControllerDecorator(ctl);
         adjustController(_ctls[*optRole], *optRole);
     }

--- a/main/main.c
+++ b/main/main.c
@@ -47,6 +47,7 @@ int app_main(void) {
 
     if (CONTROLLER_FORGET_MAC_ADDR)
     {
+        uni_bt_allowlist_remove_all();
         uni_bt_del_keys_safe();
     }
 
@@ -67,6 +68,7 @@ int app_main(void) {
     // Finally, enable the allowlist.
     // Similar to the "add_addr", its value gets stored in the NVS.
     uni_bt_allowlist_set_enabled(true);
+    uni_bt_allowlist_list();
 
     // Does not return.
     btstack_run_loop_execute();

--- a/main/sketch.cpp
+++ b/main/sketch.cpp
@@ -109,20 +109,10 @@ void setupBluepad32() {
     // By default, if the "startScanning" parameter is not passed, it will do the "start scanning".
     // Notice that "Start scanning" will try to auto-connect to devices that are compatible with Bluepad32.
     // E.g: if a Gamepad, keyboard or mouse are detected, it will try to auto connect to them.
-    bool startScanning = true;
-    BP32.setup(&onConnectedController, &onDisconnectedController, startScanning);
+    BP32.setup(&onConnectedController, &onDisconnectedController, true);
 
     // Notice that scanning can be stopped / started at any time by calling:
     // BP32.enableNewBluetoothConnections(enabled);
-
-    // "forgetBluetoothKeys()" should be called when the user performs
-    // a "device factory reset", or similar.
-    // Calling "forgetBluetoothKeys" in setup() just as an example.
-    // Forgetting Bluetooth keys prevents "paired" gamepads to reconnect.
-    // But it might also fix some connection / re-connection issues.
-    if (CONTROLLER_FORGET_MAC_ADDR) {
-        BP32.forgetBluetoothKeys();
-    }
 
     // Enables mouse / touchpad support for gamepads that support them.
     // When enabled, controllers like DualSense and DualShock4 generate two connected devices:

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size
+# Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
+nvs,      data, nvs,      0x9000,   0x6000
+phy_init, data, phy,      0xf000,   0x1000
+factory,  app,  factory,  0x10000,  1M
+coredump, data, coredump, 0x110000, 64K

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,13 +21,17 @@ board_build.embed_txtfiles =
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_mqtt_server.crt
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_claim_service_server.crt
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_ota_server.crt
+build_type = release
+  
+[env:esp32dev]
+board = esp32dev
+
+[env:esp32dev-debug]
+board = esp32dev
 build_type = debug
 board_build.partitions = partitions.csv
 ; build_flags = 
 ;  -D CORE_DEBUG_LEVEL=5
-  
-[env:esp32dev]
-board = esp32dev
 
 # It is not compiling to a linker error
 [env:esp32-s3-devkitc-1]

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,13 +13,19 @@ platform = https://github.com/pioarduino/platform-espressif32.git#53.03.10
 #framework = arduino, espidf
 framework = espidf
 monitor_speed = 115200
-monitor_filters = direct
+monitor_filters = 
+    direct
+    ; esp32_exception_decoder 
 board_build.embed_txtfiles =
     managed_components/espressif__esp_insights/server_certs/https_server.crt
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_mqtt_server.crt
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_claim_service_server.crt
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_ota_server.crt
-
+build_type = debug
+board_build.partitions = partitions.csv
+; build_flags = 
+;  -D CORE_DEBUG_LEVEL=5
+  
 [env:esp32dev]
 board = esp32dev
 


### PR DESCRIPTION
Main change is to call `uni_bt_allowlist_remove_all` when `CONTROLLER_FORGET_MAC_ADDR` is true. This allows us to change which controllers we want to restrict connecting to the ESP32 board.

However, when connecting the new JoyCons from the Switch OLED, it was crashing frequently. It appears like this may be related to this issue:
https://github.com/ricardoquesada/bluepad32/issues/86

Leaving it in `debug` mode allows the new JoyCons to connect and work fine. But when in `release` mode, it'll crash when attempting to connect.

Can we leave in `debug` mode for now?